### PR TITLE
Add dev requirements and setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,17 @@
 
 Ce dépôt contient le pipeline de données, les modèles et l’interface
 graphique pour simuler la charge des véhicules électriques au Canada.
+
+## Development Setup
+
+Install the testing dependencies using pip:
+
+```bash
+pip install -r requirements-dev.txt
+```
+
+Then run the tests with:
+
+```bash
+pytest -q
+```

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+pandas
+pytest
+numpy
+stats_can


### PR DESCRIPTION
## Summary
- add `requirements-dev.txt` with dev dependencies
- document installing test deps in `README.md`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6849eba060d08324893ceb4086b3db84