### PR TITLE
Add fuel mix table to fleet container

### DIFF
--- a/src/carDistribution.py
+++ b/src/carDistribution.py
@@ -173,11 +173,16 @@ class CarDistribution:
     def get_fuel_type(self) -> pd.DataFrame:
         """
         Returns a DataFrame of fuel‐type shares across the fleet.
-        """
-        
-        return pd.DataFrame.from_dict(
+        """         
+        # if there is nothing computed yet, return an empty DataFrame
+        if not self.fuel_type_percent:
+            return pd.DataFrame(columns=["Percent"])
+        # otherwise build the DataFrame from the stored dict
+        df = pd.DataFrame.from_dict(
             self.fuel_type_percent, orient="index", columns=["Percent"]
         )
+        df.index.name = "Fuel Type"
+        return df
 
 
     def set_fuel_type_percent_by_vehicle(self) -> None:
@@ -204,12 +209,16 @@ class CarDistribution:
         Returns per-vehicle-type percentage of the fleet as a DataFrame.
         """
         if selected_types is None:
-            selected_types = self.fuel_type_percent_by_vehicle.keys()
-        if isinstance(selected_types, list):
-            filtered = {k: v for k, v in self.fuel_type_percent_by_vehicle.items() if k in selected_types}
-            return pd.DataFrame.from_dict(
-            filtered, orient="index", columns=["Percent"]
-            )
+            # no filter → include all vehicle types
+            filtered = self.fuel_type_percent_by_vehicle
+        else:
+            # filter by the given types
+            filtered = {
+                k: v
+                for k, v in self.fuel_type_percent_by_vehicle.items()
+                if k in selected_types
+            }
+        return pd.DataFrame.from_dict(filtered, orient="index", columns=["Percent"])
 
 
     def switch_province(self, Province: str):

--- a/src/gui/app.py
+++ b/src/gui/app.py
@@ -155,15 +155,32 @@ with st.container():
     with col1:
         st.header("1 · Fleet distribution")
         st.subheader("Vehicle fleet")
-        #list of all vehicle
-        st.data_editor(electric_eff.data[["Make", "Model", "Vehicle class", "Combined (kWh/100 km)", "Recharge time (h)", "Range (km)"]].drop_duplicates(),
-                     height=300, use_container_width=True,
-                     column_config={
-                         "Active": st.column_config.CheckboxColumn(
-                             "Active",                # étiquette dans l’UI
-                             default=False             # valeur par défaut pour les nouvelles lignes
-                         )
-                     })
+        # list of all vehicles
+        st.data_editor(
+            electric_eff.data[
+                [
+                    "Make",
+                    "Model",
+                    "Vehicle class",
+                    "Combined (kWh/100 km)",
+                    "Recharge time (h)",
+                    "Range (km)",
+                ]
+            ].drop_duplicates(),
+            height=300,
+            use_container_width=True,
+            column_config={
+                "Active": st.column_config.CheckboxColumn(
+                    "Active",  # label in UI
+                    default=False,  # default for new rows
+                )
+            },
+        )
+
+        st.subheader("Fuel mix")
+        fuel_mix_df = dist.get_fuel_type().reset_index()
+        fuel_mix_df.columns = ["Fuel Type", "Percent"]
+        st.table(fuel_mix_df)
 
         st.subheader("Vehicle‑type mix")
         vt_df = dist.get_fuel_type_percent_by_vehicle(None).reset_index()


### PR DESCRIPTION
## Summary
- expand fleet container with a `Fuel mix` section
- show fuel mix table in the dashboard

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e8c90eae8832492941d3d185e10ce