### PR TITLE
Support charger level mix in arrival profiles

### DIFF
--- a/src/gui/app.py
+++ b/src/gui/app.py
@@ -351,23 +351,23 @@ if profile_mode == "Normal":
     home = arrival_profile_editor(
         "Home arrival distribution",
         n_slots=n_res,  mu0=18.0,
-        sigma0=2.0,     speed0=7.2,
+        sigma0=2.0,     ratio0=(100.0, 0.0, 0.0),
         key="home",
     )
     categories.append({
-        "share": home_share,    "profile": home["profile"], 
-        "speed": home["kW"],    "label": "Level 1 Charger",
+        "share": home_share,    "profile": home["profile"],
+        "speed": home["kW"],    "label": "Home",
     })
 
     work = arrival_profile_editor(
         "Work arrival distribution",
         n_slots=n_res,  mu0=9.0,
-        sigma0=2.0,     speed0=11.0,
+        sigma0=2.0,     ratio0=(0.0, 100.0, 0.0),
         key="work",
     )
     categories.append({
         "share": work_share,    "profile": work["profile"],
-        "speed": work["kW"],    "label": "Level 2 Charger",
+        "speed": work["kW"],    "label": "Work",
     })
 else:
     plus, minus = st.sidebar.columns(2)
@@ -388,7 +388,7 @@ else:
         prof = arrival_profile_editor(
             f"{name} arrival distribution",
             n_slots=n_res,  mu0=12.0,
-            sigma0=2.0, speed0=7.2,
+            sigma0=2.0, ratio0=(100.0, 0.0, 0.0),
             key=f"custom_{i}",
         )
         categories.append(


### PR DESCRIPTION
## Summary
- allow defining ratios of charger levels in `arrival_profile_editor`
- compute weighted charger speed from ratios
- update calls in `app.py` to pass default ratios and show home/work labels

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fea1c0fa88324b2b69b82c4803cd4