### PR TITLE
Add weekend charging mode and calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,14 @@ Then run the tests with:
 ```bash
 pytest -q
 ```
+
+## New features
+
+- Weekend charging profiles can be enabled in the interface via the sidebar
+  checkbox. When activated, home and work arrival distributions are edited
+  specifically for weekend days.
+- Weekend mode now has dedicated default values: later home arrival, later work
+  arrival and weekend driving distances pulled from StatCan data.
+- A calendar viewer is available ("Calendar" expander) which labels each day of
+  the selected year as a weekday or weekend. Statutory holidays are treated as
+  weekends.

--- a/src/util/calendar.py
+++ b/src/util/calendar.py
@@ -1,0 +1,42 @@
+import pandas as pd
+from datetime import date
+
+
+def build_calendar(year: int | None = None, prov: str | None = None) -> pd.DataFrame:
+    """Return calendar with day type for a full year.
+
+    Parameters
+    ----------
+    year : int, optional
+        Year for the calendar (defaults to current year).
+    prov : str, optional
+        Unused parameter kept for API compatibility.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Columns: ``Date`` (datetime.date), ``Day`` (weekday name),
+        ``Type`` ("Weekday" or "Weekend"). Holidays are treated as weekends.
+    """
+    if year is None:
+        year = pd.Timestamp.today().year
+    start = pd.Timestamp(year=year, month=1, day=1)
+    end = pd.Timestamp(year=year, month=12, day=31)
+    rng = pd.date_range(start, end, freq="D")
+
+    # Basic list of federal holidays (approximation)
+    hol = {
+        date(year, 1, 1),   # New Year's Day
+        date(year, 7, 1),   # Canada Day
+        date(year, 12, 25), # Christmas Day
+    }
+    records = []
+    for day in rng:
+        name = day.strftime("%A")
+        is_weekend = name in ("Saturday", "Sunday") or day.date() in hol
+        records.append({
+            "Date": day.date(),
+            "Day": name,
+            "Type": "Weekend" if is_weekend else "Weekday",
+        })
+    return pd.DataFrame(records)

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -1,0 +1,16 @@
+import pandas as pd
+from util.calendar import build_calendar
+
+
+def test_calendar_length():
+    df = build_calendar(2022)
+    assert len(df) == 365 or len(df) == 366
+    assert set(df.columns) == {"Date", "Day", "Type"}
+
+
+def test_holiday_is_weekend():
+    df = build_calendar(2022)
+    jan1 = df[df["Date"] == pd.to_datetime("2022-01-01").date()].iloc[0]
+    assert jan1["Type"] == "Weekend"
+
+


### PR DESCRIPTION
## Summary
- implement a small calendar helper that marks weekends and main holidays
- extend Streamlit app with a weekend profile option and calendar viewer
- document these features in README
- add simple tests for the calendar module
- set weekend defaults for arrival times and distance

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68768072c4a48324a1003c121bb8fedb