### PR TITLE
Add dynamic week selection for consumption chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,16 @@ Then run the tests with:
 ```bash
 pytest -q
 ```
+
+## New features
+
+- Weekend charging profiles can be enabled in the interface via the sidebar
+  checkbox. When activated, home and work arrival distributions are edited
+  specifically for weekend days.
+- Weekend mode now has dedicated default values: later home arrival, later work
+  arrival and weekend driving distances pulled from StatCan data.
+- A calendar viewer is available ("Calendar" expander) which labels each day of
+  the selected year as a weekday or weekend. Statutory holidays are treated as
+  weekends.
+- Selecting a week in the calendar updates the weekly consumption graph with the
+  appropriate mix of weekday and weekend profiles.

--- a/src/util/calendar.py
+++ b/src/util/calendar.py
@@ -1,0 +1,70 @@
+import pandas as pd
+from pandas.tseries.holiday import (
+    AbstractHolidayCalendar,
+    Holiday,
+    GoodFriday,
+    MO,
+)
+from pandas.tseries.offsets import DateOffset
+
+
+def build_calendar(year: int | None = None, prov: str | None = None) -> pd.DataFrame:
+    """Return calendar with day type for a full year.
+
+    Parameters
+    ----------
+    year : int, optional
+        Year for the calendar (defaults to current year).
+    prov : str, optional
+        Unused parameter kept for API compatibility.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Columns: ``Date`` (datetime.date), ``Day`` (weekday name),
+        ``Type`` ("Weekday" or "Weekend"). Holidays are treated as weekends.
+    """
+    if year is None:
+        year = pd.Timestamp.today().year
+    start = pd.Timestamp(year=year, month=1, day=1)
+    end = pd.Timestamp(year=year, month=12, day=31)
+    rng = pd.date_range(start, end, freq="D")
+
+    class CanadaHolidayCalendar(AbstractHolidayCalendar):
+        rules = [
+            Holiday("New Year's Day", month=1, day=1),
+            GoodFriday,
+            Holiday(
+                "Victoria Day", month=5, day=24,
+                offset=DateOffset(weekday=MO(-1))
+            ),
+            Holiday("Canada Day", month=7, day=1),
+            Holiday(
+                "Civic Holiday", month=8, day=1,
+                offset=DateOffset(weekday=MO(1))
+            ),
+            Holiday(
+                "Labour Day", month=9, day=1,
+                offset=DateOffset(weekday=MO(1))
+            ),
+            Holiday(
+                "Thanksgiving", month=10, day=1,
+                offset=DateOffset(weekday=MO(2))
+            ),
+            Holiday("Remembrance Day", month=11, day=11),
+            Holiday("Christmas Day", month=12, day=25),
+            Holiday("Boxing Day", month=12, day=26),
+        ]
+
+    cal = CanadaHolidayCalendar()
+    hol = set(cal.holidays(start=start, end=end).date)
+    records = []
+    for day in rng:
+        name = day.strftime("%A")
+        is_weekend = name in ("Saturday", "Sunday") or day.date() in hol
+        records.append({
+            "Date": day.date(),
+            "Day": name,
+            "Type": "Weekend" if is_weekend else "Weekday",
+        })
+    return pd.DataFrame(records)

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -1,0 +1,19 @@
+import pandas as pd
+from util.calendar import build_calendar
+
+
+def test_calendar_length():
+    df = build_calendar(2022)
+    assert len(df) == 365 or len(df) == 366
+    assert set(df.columns) == {"Date", "Day", "Type"}
+
+
+def test_holiday_is_weekend():
+    df = build_calendar(2022)
+    jan1 = df[df["Date"] == pd.to_datetime("2022-01-01").date()].iloc[0]
+    assert jan1["Type"] == "Weekend"
+
+    boxing = df[df["Date"] == pd.to_datetime("2022-12-26").date()].iloc[0]
+    assert boxing["Type"] == "Weekend"
+
+


### PR DESCRIPTION
## Summary
- expand `build_calendar` with federal holiday rules
- show charging profile editors for weekday & weekend
- compute week-long energy mix from selected calendar week
- document calendar week selection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68768072c4a48324a1003c121bb8fedb