### PR TITLE
docs: expand project README and add power aggregation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,60 @@
 # EV_Efficacity_2025
 
-# Modélisation charge VE
+Simulation toolkit and Streamlit dashboard for modelling the charging demand of electric vehicles across Canada. The project bundles data acquisition utilities, statistical models and an interactive UI to explore vehicle fleets, energy efficiency and charging behaviour.
 
-Ce dépôt contient le pipeline de données, les modèles et l’interface
-graphique pour simuler la charge des véhicules électriques au Canada.
+## Architecture
 
-## Development Setup
+- `CarDistribution` – summarises vehicle registrations by province and fuel type. It cleans StatCan data and exposes flexible selectors to retrieve subsets of the fleet (province, vehicle class, fuel) and helpers to compute fuel shares.
+- `CarEfficiency` – processes the federal open dataset of vehicle efficiency to average consumption and battery capacity by vehicle class.
+- `CarUsage` – retrieves NRCan tables of annual travel distances per province and transforms them into daily weekday/weekend usage and recharge energy needs.
+- `CarRecharge` – builds default weekday/weekend charging probability profiles and provides statistical samplers for session energy, duration and frequency.
+- `util.calculator.calculate_grid_power` – converts fleet size, efficiency and distance travelled into total energy demand, optionally weighted by a charging profile.
 
-Before running the test suite, install the development requirements:
+## Data sources
+
+`data_prep_canada.py` centralises data downloads:
+
+- `download_ckan_resource` pulls full tables from the open.canada.ca CKAN API and stores raw JSON for reproducibility.
+- `fetch_statcan_fleet` uses the StatsCan Web Data Service to obtain the latest light‑duty vehicle fleet by province and fuel type.
+- `CarUsage.fetchData` scrapes NRCan transport statistics to estimate daily travel distance per province.
+
+These datasets feed the domain classes above and can be cached locally in `data/raw/`.
+
+## Running the dashboard
+
+The graphical interface lives in `src/gui/app.py` and is built with Streamlit.
+To explore the model interactively:
+
+```bash
+streamlit run src/gui/app.py
+```
+
+## Development setup
+
+Create a virtual environment and install dependencies:
 
 ```bash
 pip install -r requirements-dev.txt
 ```
 
-Then run the tests with:
+Run the test suite:
 
 ```bash
 pytest -q
 ```
 
-## New features
+## Repository structure
 
-- Weekend charging profiles can be enabled in the interface via the sidebar
-  checkbox. When activated, home and work arrival distributions are edited
-  specifically for weekend days.
-- Weekend mode now has dedicated default values: later home arrival, later work
-  arrival and weekend driving distances pulled from StatCan data.
-- A calendar viewer is available ("Calendar" expander) which labels each day of
-  the selected year as a weekday or weekend. Statutory holidays are treated as
-  weekends.
-- Selecting a week in the calendar updates the weekly consumption graph with the
-  appropriate mix of weekday and weekend profiles.
+```
+src/
+├── carDistribution.py
+├── carEfficiency.py
+├── carRecharge.py
+├── carUsage.py
+├── data_prep_canada.py
+├── gui/app.py
+└── util/
+```
+
+The repository contains additional helper modules and examples (see `src/main.py`) demonstrating how to combine the classes into end‑to‑end simulations.
+

--- a/src/aggregate_power.py
+++ b/src/aggregate_power.py
@@ -1,3 +1,59 @@
 import numpy as np
 
 
+def circular_convolve(arrivals: np.ndarray, kernel: np.ndarray) -> np.ndarray:
+    """Circular discrete convolution of ``arrivals`` with ``kernel``.
+
+    Parameters
+    ----------
+    arrivals : np.ndarray
+        1‑D array where each element is the number of vehicles starting to
+        charge at the corresponding time slot.
+    kernel : np.ndarray
+        1‑D array describing the power contribution of a single vehicle over
+        subsequent slots.
+
+    Returns
+    -------
+    np.ndarray
+        Array of the same length as ``arrivals`` containing the aggregated
+        power across all slots.
+    """
+    arrivals = np.asarray(arrivals, dtype=float)
+    kernel = np.asarray(kernel, dtype=float)
+    n = arrivals.size
+    result = np.zeros(n, dtype=float)
+    for start, count in enumerate(arrivals):
+        if count == 0:
+            continue
+        for k, val in enumerate(kernel):
+            result[(start + k) % n] += count * val
+    return result
+
+
+def aggregate_power(arrivals: np.ndarray, kernels: np.ndarray) -> np.ndarray:
+    """Aggregate charging power for multiple vehicle categories.
+
+    Parameters
+    ----------
+    arrivals : np.ndarray
+        2‑D array with shape (n_slots, n_types) where each column contains the
+        number of vehicles of a given type starting to charge in each slot.
+    kernels : np.ndarray
+        2‑D array with shape (kernel_len, n_types). Column ``t`` represents the
+        per‑slot power profile of vehicles of type ``t``.
+
+    Returns
+    -------
+    np.ndarray
+        1‑D array of length ``n_slots`` giving the total power demand in each
+        slot after convolving arrivals with their respective kernels.
+    """
+    arrivals = np.asarray(arrivals, dtype=float)
+    kernels = np.asarray(kernels, dtype=float)
+    n_slots, n_types = arrivals.shape
+    total = np.zeros(n_slots, dtype=float)
+    for t in range(n_types):
+        total += circular_convolve(arrivals[:, t], kernels[:, t])
+    return total
+


### PR DESCRIPTION
## Summary
- document project architecture, data sources and setup instructions in README
- implement `circular_convolve` and `aggregate_power` utilities used by tests

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891069e55248324bde353bb7572436d