### PR TITLE
Display summary metrics and peak power on EV dashboard charts

### DIFF
--- a/src/gui/app.py
+++ b/src/gui/app.py
@@ -472,6 +472,8 @@ try:
         .properties(title="Private vehicle daily time distribution")
     )
     st.altair_chart(gauss_chart, use_container_width=True)
+    mean_time = (gauss_df["Time"] * gauss_df["Density"]).sum() / gauss_df["Density"].sum()
+    st.caption(f"Mean daily time: {mean_time:.1f} min")
 except Exception:
     pass
 
@@ -631,6 +633,8 @@ chart_cars = (
     height=350,
 )
 st.altair_chart(chart_cars, use_container_width=True)
+mean_cars = cars_df["Total_cars"].mean()
+st.caption(f"Mean cars charging: {mean_cars:.0f}")
 
 level_vars = [c for c in level_power_df.columns if c.startswith("Level ")]
 power_long = level_power_df.melt(
@@ -657,8 +661,19 @@ area_total_power = (
     )
 )
 
+max_idx = level_power_df["Agg_kW"].idxmax()
+max_point = (
+    alt.Chart(level_power_df.iloc[[max_idx]])
+    .mark_point(color="red", size=100)
+    .encode(x="Time", y="Agg_kW")
+)
+
+daily_energy = (level_power_df["Agg_kW"] * slot_len).sum()
+max_power = level_power_df.loc[max_idx, "Agg_kW"]
+max_time = level_power_df.loc[max_idx, "Time"]
+
 chart_power = (
-    line_levels + area_total_power
+    line_levels + area_total_power + max_point
 ).properties(
     title=f"Power demand over time ({', '.join(province)}, "
     f"{selected_types if selected_types is not None else 'Average'} vehicle)",
@@ -666,6 +681,7 @@ chart_power = (
     height=350,
 )
 st.altair_chart(chart_power, use_container_width=True)
+st.caption(f"Daily energy: {daily_energy:.2f} kWh — Peak {max_power:.1f} kW at {max_time}")
 slot_hours = slot_len
 weekday_power_base["Energy_Wh"] = weekday_power_base["Agg_kW"] * slot_hours * 1000
 weekend_power_base["Energy_Wh"] = weekend_power_base["Agg_kW"] * slot_hours * 1000

--- a/src/gui/app.py
+++ b/src/gui/app.py
@@ -486,9 +486,11 @@ try:
     )
     st.altair_chart(gauss_chart, use_container_width=True)
     mean_time = (gauss_df["Time"] * gauss_df["Density"]).sum() / gauss_df["Density"].sum()
-    st.caption(f"Mean daily time: {_format_si(mean_time, 'min')}")
+    st.caption(
+        f"Mean daily time: {_format_si(mean_time, 'min')} — Average distance driven: {_format_si(avg_distance, 'km/day')}"
+    )
 except Exception:
-    pass
+    st.caption(f"Average distance driven: {_format_si(avg_distance, 'km/day')}")
 
 # ─────── Custom charging profiles ───────────────────────────────────────────────────────────────────────────────────────────
 st.sidebar.header("Charging profiles")


### PR DESCRIPTION
## Summary
- Show mean daily time on the private vehicle distribution chart.
- Display average number of charging cars below the charging over time graph.
- Add daily energy calculation and highlight peak power on the power demand chart.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894f7d0cacc832497407e4c6e172902